### PR TITLE
Changed nuspec over to static version number

### DIFF
--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.7.0.*")]
+[assembly: AssemblyVersion("2.8.0.*")]
 //[assembly: AssemblyFileVersion("1.0.1.*")]
 
 [assembly: CLSCompliant(true)]


### PR DESCRIPTION
This is in line with how we maintain other external packages.

@jameswelle Changing this over to mimic the flow we use for https://github.com/articulate/Articulate.Desktop.Branding