### PR TITLE
Allow empty paths to remain empty

### DIFF
--- a/Source/Paths/SvgPath.cs
+++ b/Source/Paths/SvgPath.cs
@@ -71,8 +71,11 @@ namespace Svg
                         // Calculate boundary including stroke width.
                         var radius = StrokeWidth * 2;
                         var bounds = _path.GetBounds();
-                        _path.AddEllipse(bounds.Left - radius, bounds.Top - radius, 2 * radius, 2 * radius);
-                        _path.AddEllipse(bounds.Right - radius, bounds.Bottom - radius, 2 * radius, 2 * radius);
+                        if (!bounds.IsEmpty)
+                        {
+                            _path.AddEllipse(bounds.Left - radius, bounds.Top - radius, 2 * radius, 2 * radius);
+                            _path.AddEllipse(bounds.Right - radius, bounds.Bottom - radius, 2 * radius, 2 * radius);
+                        }
                     }
                 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.1.1.{build}
+version: 3.1.2.{build}
 image: Visual Studio 2019
 pull_requests:
   do_not_increment_build_number: true


### PR DESCRIPTION
A change upstream to account for stroke width when determining path bounds introduced an issue where an empty path would report bounds that weren't actually empty. This skews the entire bounds calculation for the SVG document

[#174662536] SVG Library Upgrade
